### PR TITLE
added new-post template

### DIFF
--- a/controllers/dashboard-routes.js
+++ b/controllers/dashboard-routes.js
@@ -2,6 +2,7 @@
 const router = require('express').Router();
 const { User, Post, Comment } = require('../models');
 const withAuth = require('../utils/auth');
+const { post } = require('./home-routes');
 
 // retrieve all the post created by the currently authenticated user and the associated user information and comments. order by creation date
 router.get('/', withAuth, (req, res) => {
@@ -39,3 +40,53 @@ router.get('/', withAuth, (req, res) => {
         res.status(500).json(err);
     });
 });
+
+// handler retrieves a specific post and the associated user info and comments from the db based on provided post id. 
+router.get('/edit/:id', withAuth, (req, res) => {
+    Post.findOne({
+      where: {
+        id: req.params.id
+      },
+      attributes: ['id', 'title', 'post_text', 'created_at'],
+      include: [
+        {
+          model: User,
+          attributes: ['username']
+        },
+        {
+          model: Comment,
+          attributes: ['id', 'comment_text', 'post_id', 'user_id', 'created_at'],
+          include: {
+            model: User,
+            attributes: ['username']
+          }
+        }
+      ]
+    })
+    // handle the response after retrieving post from db. if no post is found return 404 error response. If found render the 'edit-post' template. 
+      .then(dbPostData => {
+        if (!dbPostData) {
+          res.status(404).json({ message: 'No post found with this id' });
+          return;
+        }
+        //serialize the data
+        const post = dbPostData.get({ plain: true });
+        // pass to the template
+        res.render('edit-post', {
+          post,
+          loggedIn: req.session.loggedIn
+        });
+      })
+      .catch(err => {
+        console.log(err);
+        res.status(500).json(err);
+      });
+  });
+  
+  // render the 'new-post' template to create a new post
+  router.get('/new', (req, res) => {
+    res.render('new-post');
+  });
+  
+  
+  module.exports = router;


### PR DESCRIPTION
This pull request introduces two new route handlers to the router file. Here's an overview of the changes made:

Added a new route handler for the "/edit/:id" path that is protected by the "withAuth" middleware, ensuring that only authenticated users can access it. Within this handler, it retrieves a specific post and its associated user information and comments from the database based on the provided post ID.

After successfully retrieving the data, it checks if the post exists. If not, it sends a 404 error response. If the post is found, it serializes the data by converting it into a plain JavaScript object. Then, it renders the "edit-post" template, passing the post data and the logged-in status of the current session.

Implemented error handling for any errors that occur during the database retrieval or template rendering. If an error occurs, it logs the error to the console and sends a 500 error response.

Added a new route handler for the "/new" path, which simply renders the "new-post" template. This template is used for creating a new post.

These changes enhance the functionality of the router file by providing routes for editing existing posts and creating new posts.