### PR TITLE
updated delete-post.js

### DIFF
--- a/public/javascript/delete-post.js
+++ b/public/javascript/delete-post.js
@@ -1,0 +1,19 @@
+async function deleteFormHandler(event) {
+    event.preventDefault();
+  
+    const id = window.location.toString().split('/')[
+      window.location.toString().split('/').length-1
+    ];
+  
+    const response = await fetch(`/api/posts/${id}`, {
+      method: 'DELETE',    
+    });    
+  
+    if (response.ok) {
+      document.location.replace('/dashboard/');
+    } else {
+      alert(response.statusText);
+    }
+  }
+  
+  document.querySelector('.delete-post-btn').addEventListener('click', deleteFormHandler);


### PR DESCRIPTION
This commit adds an event listener and handler to the delete post button. When the button is clicked, the handler function deleteFormHandler is called. It prevents the default button behavior, extracts the post ID from the current window location, and sends a DELETE request to the server at the /api/posts/{id} endpoint to delete the corresponding post. If the response from the server is successful (status code 200), the page is redirected to the dashboard. Otherwise, an alert is shown with the status text from the response.