### PR TITLE
updated dashboard.handlebar

### DIFF
--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -1,0 +1,18 @@
+{{#if posts.length}}
+<section>
+  <h2>Your Posts</h2>
+  <ol class="post-list">
+    {{#each posts as |post|}}
+    <li>
+      {{> dashboard-post-info post}}      
+    </li>
+    {{/each}}
+  </ol>
+</section>
+{{else}}
+<section>
+  <h3>No posts available yet!</h3>
+</section>
+{{/if}}
+
+<button type="submit"><a href="/dashboard/new">Add New Post</a></button>


### PR DESCRIPTION
Implement dashboard post display and add new post button: Added code to display the user's posts on the dashboard. If the user has posts, they are rendered as a list using a partial template called 'dashboard-post-info'. If there are no posts, a message indicating the absence of posts is displayed. Additionally, included a button that allows users to add a new post by redirecting them to the '/dashboard/new' route. This update enhances the user experience on the dashboard page by providing post visibility and easy access to creating new posts.